### PR TITLE
fix JSON ProtocolBuf Encoding

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,4 +25,4 @@ linters-settings:
   gocyclo:
     min-complexity: 15
   errcheck:
-    exclude-functions: fmt:.*,io/ioutil/net:^Read,^Close|^Write|,http:^Shutdown
+    exclude-functions: fmt:.*,io/ioutil/net/http:^Read,^Close|^Write|,http:^Shutdown

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func main() {
 	}
 	mux := otlp.NewServerMux()
 	enc := func(ctx context.Context, msg proto.Message) {
-		bs, err := protojson.Marshal(msg)
+		bs, err := otlp.MarshalJSON(msg)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to marshal proto message", "msg", err)
 			return
@@ -217,7 +217,7 @@ func main() {
 	)
 	mux := otlp.NewServerMux()
 	enc := func(ctx context.Context, msg proto.Message) {
-		bs, err := protojson.Marshal(msg)
+		bs, err := otlp.MarshalJSON(msg)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to marshal proto message", "msg", err)
 			return

--- a/examples/client/go.mod
+++ b/examples/client/go.mod
@@ -7,7 +7,6 @@ replace github.com/mashiike/go-otlp-helper => ../../
 require (
 	github.com/mashiike/go-otlp-helper v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/proto/otlp v1.3.1
-	google.golang.org/protobuf v1.34.2
 )
 
 require (
@@ -18,4 +17,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/grpc v1.67.0 // indirect
+	google.golang.org/protobuf v1.34.2 // indirect
 )

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -14,7 +14,6 @@ import (
 	common "go.opentelemetry.io/proto/otlp/common/v1"
 	resource "go.opentelemetry.io/proto/otlp/resource/v1"
 	trace "go.opentelemetry.io/proto/otlp/trace/v1"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func main() {
@@ -101,10 +100,7 @@ func dumpResourceSpans(resourceSpans []*trace.ResourceSpans) {
 	req := &otlp.TraceRequest{
 		ResourceSpans: resourceSpans,
 	}
-	bs, err := protojson.MarshalOptions{
-		Multiline: true,
-		Indent:    "  ",
-	}.Marshal(req)
+	bs, err := otlp.MarshalIndentJSON(req, "  ")
 	if err != nil {
 		slog.Error("failed to marshal request", "details", err)
 		os.Exit(1)

--- a/examples/grpc/main.go
+++ b/examples/grpc/main.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -28,7 +27,7 @@ func main() {
 	}
 	mux := otlp.NewServerMux()
 	enc := func(ctx context.Context, msg proto.Message) {
-		bs, err := protojson.Marshal(msg)
+		bs, err := otlp.MarshalJSON(msg)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to marshal proto message", "msg", err)
 			return

--- a/examples/lambda/main.go
+++ b/examples/lambda/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/fujiwara/ridge"
 	"github.com/mashiike/go-otlp-helper/otlp"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -20,7 +19,7 @@ func main() {
 	)
 	mux := otlp.NewServerMux()
 	enc := func(ctx context.Context, msg proto.Message) {
-		bs, err := protojson.Marshal(msg)
+		bs, err := otlp.MarshalJSON(msg)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to marshal proto message", "msg", err)
 			return

--- a/otlp/client.go
+++ b/otlp/client.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -210,7 +209,7 @@ func newHTTPRequest[T proto.Message](ctx context.Context, so *clientSignalsOptio
 	if contentType == "application/x-protobuf" {
 		bs, err = proto.Marshal(body)
 	} else {
-		bs, err = protojson.Marshal(body)
+		bs, err = MarshalJSON(body)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal body: %w", err)
@@ -270,7 +269,7 @@ func (c *Client) uploadTracesWithHTTP(ctx context.Context, protoSpans []*Resourc
 			return fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	case "application/json":
-		if err := protojson.Unmarshal(respBody, &respData); err != nil {
+		if err := UnmarshalJSON(respBody, &respData); err != nil {
 			return fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	default:
@@ -367,7 +366,7 @@ func (c *Client) uploadMetricsWithHTTP(ctx context.Context, protoMetrics []*Reso
 			return fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	case "application/json":
-		if err := protojson.Unmarshal(respBody, &respData); err != nil {
+		if err := UnmarshalJSON(respBody, &respData); err != nil {
 			return fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	default:
@@ -463,7 +462,7 @@ func (c *Client) uploadLogsWithHTTP(ctx context.Context, protoLogs []*ResourceLo
 			return fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	case "application/json":
-		if err := protojson.Unmarshal(respBody, &respData); err != nil {
+		if err := UnmarshalJSON(respBody, &respData); err != nil {
 			return fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 	default:

--- a/otlp/json.go
+++ b/otlp/json.go
@@ -1,0 +1,154 @@
+package otlp
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type JSONEncoder struct {
+	writer    io.Writer
+	marshaler protojson.MarshalOptions
+}
+
+func NewJSONEncoder(writer io.Writer) *JSONEncoder {
+	return &JSONEncoder{
+		writer: writer,
+		marshaler: protojson.MarshalOptions{
+			UseEnumNumbers:  true,
+			EmitUnpopulated: false,
+		},
+	}
+}
+
+func (e *JSONEncoder) SetIndent(indent string) {
+	e.marshaler.Multiline = true
+	e.marshaler.Indent = indent
+}
+func (e *JSONEncoder) Encode(msg proto.Message) error {
+	data, err := e.marshaler.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	data = convertTraceIDAndSpanIDBase64ToHex(data)
+	_, err = e.writer.Write(data)
+	return err
+}
+
+func convertTraceIDAndSpanIDBase64ToHex(data []byte) []byte {
+	var m any
+	if err := json.Unmarshal(data, &m); err != nil {
+		slog.Warn("failed to convert traceID and spanID from base64 to hex", "error", err.Error())
+		return data
+	}
+	m = convertTraceIDAndSpanIDBase64ToHexForAny(m)
+	converted, err := json.Marshal(m)
+	if err != nil {
+		slog.Warn("failed to convert traceID and spanID from base64 to hex", "error", err.Error())
+		return data
+	}
+	return converted
+}
+
+func convertTraceIDAndSpanIDBase64ToHexForAny(data any) any {
+	switch data := data.(type) {
+	case map[string]interface{}:
+		return convertTraceIDAndSpanIDBase64ToHexForMap(data)
+	case []interface{}:
+		for i, v := range data {
+			data[i] = convertTraceIDAndSpanIDBase64ToHexForAny(v)
+		}
+	}
+	return data
+}
+
+func keyIsTraceIDOrSpanID(k string) bool {
+	return strings.EqualFold(strings.ReplaceAll(k, "_", ""), "traceId") || strings.EqualFold(strings.ReplaceAll(k, "_", ""), "spanId")
+}
+
+func convertTraceIDAndSpanIDBase64ToHexForMap(data map[string]interface{}) map[string]interface{} {
+	for k, v := range data {
+		if keyIsTraceIDOrSpanID(k) {
+			if s, ok := v.(string); ok {
+				bs, err := base64.StdEncoding.DecodeString(s)
+				if err != nil {
+					slog.Warn("failed to convert traceID and spanID from base64 to hex", "error", err.Error())
+				} else {
+					data[k] = strings.ToUpper(hex.EncodeToString(bs))
+				}
+				continue
+			}
+			slog.Warn("unexpected type of traceID and spanID", "key", k, "value_type", fmt.Sprintf("%T", v))
+		}
+		data[k] = convertTraceIDAndSpanIDBase64ToHexForAny(v)
+	}
+	return data
+}
+
+type JSONDecoder struct {
+	dec  *json.Decoder
+	opts protojson.UnmarshalOptions
+}
+
+func NewJSONDecoder(reader io.Reader) *JSONDecoder {
+	return &JSONDecoder{
+		dec:  json.NewDecoder(reader),
+		opts: protojson.UnmarshalOptions{},
+	}
+}
+
+func (d *JSONDecoder) More() bool {
+	return d.dec.More()
+}
+
+func (d *JSONDecoder) Decode(msg proto.Message) error {
+	var m any
+	if err := d.dec.Decode(&m); err != nil {
+		return err
+	}
+	m = convertTraceIDAndSpanIDHexToBase64ForAny(m)
+	data, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return d.opts.Unmarshal(data, msg)
+}
+
+func convertTraceIDAndSpanIDHexToBase64ForAny(data any) any {
+	switch data := data.(type) {
+	case map[string]interface{}:
+		return convertTraceIDAndSpanIDHexToBase64ForMap(data)
+	case []interface{}:
+		for i, v := range data {
+			data[i] = convertTraceIDAndSpanIDHexToBase64ForAny(v)
+		}
+	}
+	return data
+}
+
+func convertTraceIDAndSpanIDHexToBase64ForMap(data map[string]interface{}) map[string]interface{} {
+	for k, v := range data {
+		if keyIsTraceIDOrSpanID(k) {
+			if s, ok := v.(string); ok {
+				bs, err := hex.DecodeString(s)
+				if err != nil {
+					slog.Warn("failed to convert traceID and spanID from hex to base64", "error", err.Error())
+				} else {
+					data[k] = base64.StdEncoding.EncodeToString(bs)
+				}
+				continue
+			}
+			slog.Warn("unexpected type of traceID and spanID", "key", k, "value_type", fmt.Sprintf("%T", v))
+		}
+		data[k] = convertTraceIDAndSpanIDHexToBase64ForAny(v)
+	}
+	return data
+}

--- a/otlp/json.go
+++ b/otlp/json.go
@@ -95,7 +95,9 @@ func convertTraceIDAndSpanIDBase64ToHexForAny(data any) any {
 }
 
 func keyIsTraceIDOrSpanID(k string) bool {
-	return strings.EqualFold(strings.ReplaceAll(k, "_", ""), "traceId") || strings.EqualFold(strings.ReplaceAll(k, "_", ""), "spanId")
+	key := strings.ReplaceAll(k, "_", "")
+	key = strings.ToLower(key)
+	return strings.Contains(key, "traceid") || strings.Contains(key, "spanid")
 }
 
 func convertTraceIDAndSpanIDBase64ToHexForMap(data map[string]interface{}) map[string]interface{} {

--- a/otlp/json.go
+++ b/otlp/json.go
@@ -55,6 +55,7 @@ func (e *JSONEncoder) SetIndent(indent string) {
 	e.marshaler.Multiline = true
 	e.marshaler.Indent = indent
 }
+
 func (e *JSONEncoder) Encode(msg proto.Message) error {
 	data, err := e.marshaler.Marshal(msg)
 	if err != nil {

--- a/otlp/json_test.go
+++ b/otlp/json_test.go
@@ -25,7 +25,7 @@ func TestJSONEncoding_Trace(t *testing.T) {
 	require.NotNil(t, attr)
 	require.Equal(t, "service.name", attr.GetKey())
 	require.NotNil(t, attr.GetValue())
-	require.Equal(t, "example-service", attr.GetValue().GetStringValue())
+	require.Equal(t, "my.service", attr.GetValue().GetStringValue())
 	ss := rs.GetScopeSpans()
 	require.Len(t, ss, 1)
 	spans := ss[0].GetSpans()

--- a/otlp/json_test.go
+++ b/otlp/json_test.go
@@ -1,0 +1,40 @@
+package otlp_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/mashiike/go-otlp-helper/otlp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONEncoding_Trace(t *testing.T) {
+	bs, err := os.ReadFile("testdata/trace.json")
+	require.NoError(t, err)
+	dec := otlp.NewJSONDecoder(bytes.NewReader(bs))
+	var req otlp.TraceRequest
+	require.NoError(t, dec.Decode(&req))
+	require.Len(t, req.GetResourceSpans(), 1)
+	rs := req.GetResourceSpans()[0]
+	require.NotNil(t, rs)
+	r := rs.GetResource()
+	require.NotNil(t, r)
+	require.Len(t, r.GetAttributes(), 1)
+	attr := r.GetAttributes()[0]
+	require.NotNil(t, attr)
+	require.Equal(t, "service.name", attr.GetKey())
+	require.NotNil(t, attr.GetValue())
+	require.Equal(t, "example-service", attr.GetValue().GetStringValue())
+	ss := rs.GetScopeSpans()
+	require.Len(t, ss, 1)
+	spans := ss[0].GetSpans()
+	require.Len(t, spans, 1)
+	require.Len(t, spans[0].GetTraceId(), 16)
+	require.Len(t, spans[0].GetSpanId(), 8)
+
+	var buf bytes.Buffer
+	enc := otlp.NewJSONEncoder(&buf)
+	require.NoError(t, enc.Encode(&req))
+	require.JSONEq(t, string(bs), buf.String())
+}

--- a/otlp/json_test.go
+++ b/otlp/json_test.go
@@ -32,6 +32,7 @@ func TestJSONEncoding_Trace(t *testing.T) {
 	require.Len(t, spans, 1)
 	require.Len(t, spans[0].GetTraceId(), 16)
 	require.Len(t, spans[0].GetSpanId(), 8)
+	require.Len(t, spans[0].GetParentSpanId(), 8)
 
 	var buf bytes.Buffer
 	enc := otlp.NewJSONEncoder(&buf)

--- a/otlp/proxy.go
+++ b/otlp/proxy.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -68,7 +67,7 @@ func errorProto(w http.ResponseWriter, st *status.Status) {
 
 func errorJSON(w http.ResponseWriter, st *status.Status) {
 	httpStatus := grpcCodeToHTTPStatus(st.Code())
-	bs, err := protojson.Marshal(st.Proto())
+	bs, err := MarshalJSON(st.Proto())
 	if err != nil {
 		http.Error(w, http.StatusText(httpStatus), httpStatus)
 	}
@@ -159,7 +158,7 @@ func (h *proxyHandler[Req, Resp]) serveHTTPWithJSON(w http.ResponseWriter, r *ht
 		return
 	}
 	defer r.Body.Close()
-	if err := protojson.Unmarshal(bs, req); err != nil {
+	if err := UnmarshalJSON(bs, req); err != nil {
 		st := status.New(codes.InvalidArgument, "Unable to unmarshal request body")
 		st, _ = st.WithDetails(&errdetails.ErrorInfo{Reason: err.Error()})
 		errorJSON(w, st)
@@ -174,7 +173,7 @@ func (h *proxyHandler[Req, Resp]) serveHTTPWithJSON(w http.ResponseWriter, r *ht
 		errorJSON(w, status.New(codes.Internal, err.Error()))
 		return
 	}
-	data, err := protojson.Marshal(resp)
+	data, err := MarshalJSON(resp)
 	if err != nil {
 		st := status.New(codes.Internal, "Unable to marshal response")
 		st, _ = st.WithDetails(&errdetails.ErrorInfo{Reason: err.Error()})

--- a/otlp/testdata/logs.json
+++ b/otlp/testdata/logs.json
@@ -6,25 +6,7 @@
           {
             "key": "service.name",
             "value": {
-              "stringValue": "unknown_service:otlp.test"
-            }
-          },
-          {
-            "key": "telemetry.sdk.language",
-            "value": {
-              "stringValue": "go"
-            }
-          },
-          {
-            "key": "telemetry.sdk.name",
-            "value": {
-              "stringValue": "opentelemetry"
-            }
-          },
-          {
-            "key": "telemetry.sdk.version",
-            "value": {
-              "stringValue": "1.30.0"
+              "stringValue": "my.service"
             }
           }
         ]
@@ -32,35 +14,88 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "test"
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "some scope attribute"
+                }
+              }
+            ]
           },
           "logRecords": [
             {
-              "timeUnixNano": "1727164332881997000",
-              "observedTimeUnixNano": "1727164332882007000",
-              "severityNumber": "SEVERITY_NUMBER_INFO",
+              "timeUnixNano": "1544712660300000000",
+              "observedTimeUnixNano": "1544712660300000000",
+              "severityNumber": 10,
+              "severityText": "Information",
+              "traceId": "5B8EFFF798038103D269B633813FC60C",
+              "spanId": "EEE19B7EC3C1B174",
               "body": {
-                "stringValue": "test log"
+                "stringValue": "Example log record"
               },
               "attributes": [
                 {
-                  "key": "user",
+                  "key": "string.attribute",
                   "value": {
-                    "stringValue": "test user"
+                    "stringValue": "some string"
                   }
                 },
                 {
-                  "key": "admin",
+                  "key": "boolean.attribute",
                   "value": {
                     "boolValue": true
+                  }
+                },
+                {
+                  "key": "int.attribute",
+                  "value": {
+                    "intValue": "10"
+                  }
+                },
+                {
+                  "key": "double.attribute",
+                  "value": {
+                    "doubleValue": 637.704
+                  }
+                },
+                {
+                  "key": "array.attribute",
+                  "value": {
+                    "arrayValue": {
+                      "values": [
+                        {
+                          "stringValue": "many"
+                        },
+                        {
+                          "stringValue": "values"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "map.attribute",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "some.map.key",
+                          "value": {
+                            "stringValue": "some value"
+                          }
+                        }
+                      ]
+                    }
                   }
                 }
               ]
             }
           ]
         }
-      ],
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0"
+      ]
     }
   ]
 }

--- a/otlp/testdata/metrics.json
+++ b/otlp/testdata/metrics.json
@@ -6,25 +6,7 @@
           {
             "key": "service.name",
             "value": {
-              "stringValue": "unknown_service:otlp.test"
-            }
-          },
-          {
-            "key": "telemetry.sdk.language",
-            "value": {
-              "stringValue": "go"
-            }
-          },
-          {
-            "key": "telemetry.sdk.name",
-            "value": {
-              "stringValue": "opentelemetry"
-            }
-          },
-          {
-            "key": "telemetry.sdk.version",
-            "value": {
-              "stringValue": "1.30.0"
+              "stringValue": "my.service"
             }
           }
         ]
@@ -32,27 +14,127 @@
       "scopeMetrics": [
         {
           "scope": {
-            "name": "test"
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "some scope attribute"
+                }
+              }
+            ]
           },
           "metrics": [
             {
-              "name": "test",
+              "name": "my.counter",
+              "unit": "1",
+              "description": "I am a Counter",
               "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": true,
                 "dataPoints": [
                   {
-                    "startTimeUnixNano": "1727162867948315000",
-                    "timeUnixNano": "1727162867948351000",
-                    "asInt": "1"
+                    "asDouble": 5,
+                    "startTimeUnixNano": "1544712660300000000",
+                    "timeUnixNano": "1544712660300000000",
+                    "attributes": [
+                      {
+                        "key": "my.counter.attr",
+                        "value": {
+                          "stringValue": "some value"
+                        }
+                      }
+                    ]
                   }
-                ],
-                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                "isMonotonic": true
+                ]
+              }
+            },
+            {
+              "name": "my.gauge",
+              "unit": "1",
+              "description": "I am a Gauge",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 10,
+                    "timeUnixNano": "1544712660300000000",
+                    "attributes": [
+                      {
+                        "key": "my.gauge.attr",
+                        "value": {
+                          "stringValue": "some value"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "my.histogram",
+              "unit": "1",
+              "description": "I am a Histogram",
+              "histogram": {
+                "aggregationTemporality": 1,
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "1544712660300000000",
+                    "timeUnixNano": "1544712660300000000",
+                    "count": 2,
+                    "sum": 2,
+                    "bucketCounts": [1,1],
+                    "explicitBounds": [1],
+                    "min": 0,
+                    "max": 2,
+                    "attributes": [
+                      {
+                        "key": "my.histogram.attr",
+                        "value": {
+                          "stringValue": "some value"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "my.exponential.histogram",
+              "unit": "1",
+              "description": "I am an Exponential Histogram",
+              "exponentialHistogram": {
+                "aggregationTemporality": 1,
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "1544712660300000000",
+                    "timeUnixNano": "1544712660300000000",
+                    "count": 3,
+                    "sum": 10,
+                    "scale": 0,
+                    "zeroCount": 1,
+                    "positive": {
+                      "offset": 1,
+                      "bucketCounts": [0,2]
+                    },
+                    "min": 0,
+                    "max": 5,
+                    "zeroThreshold": 0,
+                    "attributes": [
+                      {
+                        "key": "my.exponential.histogram.attr",
+                        "value": {
+                          "stringValue": "some value"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             }
           ]
         }
-      ],
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0"
+      ]
     }
   ]
 }

--- a/otlp/testdata/trace.json
+++ b/otlp/testdata/trace.json
@@ -15,14 +15,15 @@
         {
           "spans": [
             {
-              "traceId": "0000000000000001",
-              "spanId": "00000001",
+              "traceId": "5B8EFFF798038103D269B633813FC60C",
+              "spanId": "EEE19B7EC3C1B174",
+              "parentSpanId": "EEE19B7EC3C1B173",
               "name": "example-span",
-              "kind": "SPAN_KIND_INTERNAL",
+              "kind": 2,
               "startTimeUnixNano": "1631765994860224000",
               "endTimeUnixNano": "1631765994863224000",
               "status": {
-                "code": "STATUS_CODE_OK"
+                "code": 1
               }
             }
           ]

--- a/otlp/testdata/trace.json
+++ b/otlp/testdata/trace.json
@@ -6,25 +6,42 @@
           {
             "key": "service.name",
             "value": {
-              "stringValue": "example-service"
+              "stringValue": "my.service"
             }
           }
         ]
       },
       "scopeSpans": [
         {
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "some scope attribute"
+                }
+              }
+            ]
+          },
           "spans": [
             {
               "traceId": "5B8EFFF798038103D269B633813FC60C",
               "spanId": "EEE19B7EC3C1B174",
               "parentSpanId": "EEE19B7EC3C1B173",
-              "name": "example-span",
+              "name": "I'm a server span",
+              "startTimeUnixNano": "1544712660000000000",
+              "endTimeUnixNano": "1544712661000000000",
               "kind": 2,
-              "startTimeUnixNano": "1631765994860224000",
-              "endTimeUnixNano": "1631765994863224000",
-              "status": {
-                "code": 1
-              }
+              "attributes": [
+                {
+                  "key": "my.span.attr",
+                  "value": {
+                    "stringValue": "some value"
+                  }
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
https://opentelemetry.io/docs/specs/otlp/

> The traceId and spanId byte arrays are represented as [case-insensitive hex-encoded strings](https://tools.ietf.org/html/rfc4648#section-8); they are not base64-encoded as is defined in the standard [Protobuf JSON Mapping](https://developers.google.com/protocol-buffers/docs/proto3#json). Hex encoding is used for traceId and spanId fields in all OTLP Protobuf messages, e.g., the Span, Link, LogRecord, etc. messages. For example, the traceId field in a Span can be represented like this: { “traceId”: “5B8EFFF798038103D269B633813FC60C”, … }

this implement is base64 encoding
fix and changes